### PR TITLE
Load both php and json language files

### DIFF
--- a/src/MaticeServiceProvider.php
+++ b/src/MaticeServiceProvider.php
@@ -112,7 +112,12 @@ class MaticeServiceProvider extends ServiceProvider
 
                     if ($extension === '.json') {
 
-                        $tree[$ff] = json_decode(File::get($pathName), true);
+                        $existingTranslations = $tree[$ff] ?? [];
+
+                        $tree[$ff] = array_merge(
+                            $existingTranslations,
+                            json_decode(File::get($pathName), true)
+                        );
 
                     } else if ($extension === '.php') {
 

--- a/src/MaticeServiceProvider.php
+++ b/src/MaticeServiceProvider.php
@@ -106,9 +106,9 @@ class MaticeServiceProvider extends ServiceProvider
 
                     $tree[$ff] = MaticeServiceProvider::makeFolderFilesTree($dir . '/' . $ff);
 
-                } else {
+                }
 
-                    $pathName = $dir . '/' . $ff . $extension;
+                if (is_file($pathName = $dir . '/' . $ff . $extension)) {
 
                     if ($extension === '.json') {
 


### PR DESCRIPTION
Because you can have both language files, classic language PHP files and one JSON file.
E.G. for [Laravel Jetstream](https://jetstream.laravel.com/1.x/introduction.html) and [Laravel Fortify](https://github.com/laravel/fortify).

Sample Laravel application structure:
```
resources/lang/fr/auth.php
resources/lang/fr/pagination.php
...
resources/lang/fr.json
```
Resources:
* https://laravel.com/docs/8.x/localization#using-translation-strings-as-keys
* https://github.com/Laravel-Lang/lang/tree/7.0.8/src
* https://github.com/Laravel-Lang/lang/tree/7.0.8/json