### PR TITLE
Support translation key with dot

### DIFF
--- a/src/js/Localization/core.ts
+++ b/src/js/Localization/core.ts
@@ -182,17 +182,18 @@ class Localization {
    * @param key
    * @param silentNotFoundError
    * @param locale
+   * @param splitKey
    * @returns {string}
    * @private
    */
-  private findSentence(key: string, silentNotFoundError: boolean, locale: string = MaticeLocalizationConfig.locale): string {
+  private findSentence(key: string, silentNotFoundError: boolean, locale: string = MaticeLocalizationConfig.locale, splitKey: boolean = true): string {
     const translations: { [key: string]: any } = this.translations(locale)
 
     // At first [link] is a [Map<String, dynamic>] but at the end, it can be a [String],
     // the sentences.
     let link = translations
 
-    const parts = key.split('.')
+    const parts = splitKey ? key.split('.') : [key]
 
     for (const part of parts) {
       // Get the new json until we fall on the last key of
@@ -205,9 +206,14 @@ class Localization {
         // @ts-ignore
         link = link[part]
       } catch (e) {
+        // If key not found, try without splitting it.
+        if (splitKey) {
+          return this.findSentence(key, silentNotFoundError, locale, false)
+        }
+
         // If key not found, try with the fallback locale.
         if (locale !== MaticeLocalizationConfig.fallbackLocale) {
-          return this.findSentence(key, silentNotFoundError, MaticeLocalizationConfig.fallbackLocale)
+          return this.findSentence(key, silentNotFoundError, MaticeLocalizationConfig.fallbackLocale, splitKey)
         }
 
         // If the key not found and the silent mode is on, return the key,

--- a/src/js/Localization/core.ts
+++ b/src/js/Localization/core.ts
@@ -213,7 +213,7 @@ class Localization {
 
         // If key not found, try with the fallback locale.
         if (locale !== MaticeLocalizationConfig.fallbackLocale) {
-          return this.findSentence(key, silentNotFoundError, MaticeLocalizationConfig.fallbackLocale, splitKey)
+          return this.findSentence(key, silentNotFoundError, MaticeLocalizationConfig.fallbackLocale)
         }
 
         // If the key not found and the silent mode is on, return the key,

--- a/tests/js/manage_translation.test.ts
+++ b/tests/js/manage_translation.test.ts
@@ -14,7 +14,9 @@ global.Matice = {
     "fr": {
       "greet": {
         "me": "Bonjour!"
-      }
+      },
+      "Key with one dot. Should be OK": "Avec un point, c'est bien.",
+      "Key with dots. Should be better...": "Avec plusieurs points, c'est mieux..."
     }
   },
   "locale": "en",
@@ -30,7 +32,7 @@ test('Retrieves simple sentence.', () => {
   expect(sentence).toEqual("Hello!")
 
   expect(() => trans('greet.unknown'))
-    .toThrow(`Translation key not found : "greet.unknown" -> Exactly "unknown" not found`)
+    .toThrow(`Translation key not found : "greet.unknown" -> Exactly "greet.unknown" not found`)
 
   sentence = __('greet.unknown')
   expect(sentence).toEqual('greet.unknown')
@@ -50,6 +52,14 @@ test('Retrieves simple sentence.', () => {
   // greet.meMore in french so fallback to english.
   sentence = __('greet.meMore')
   expect(sentence).toEqual('Hello Ekcel Henrich!')
+    
+  // Test translation key with one dot
+  sentence = trans('Key with one dot. Should be OK')
+  expect(sentence).toEqual("Avec un point, c'est bien.")
+    
+  // Test translation key with multiple dots
+  sentence = trans('Key with dots. Should be better...')
+  expect(sentence).toEqual("Avec plusieurs points, c'est mieux...")
 });
 
 


### PR DESCRIPTION
Add a `splitKey` flag to the [`Localization::findSentence()`](https://github.com/GENL/matice/blob/50c08a0c12643bd8077e006e1aa9100e1445db87/src/js/Localization/core.ts#L188) method

Sample:
```javascript
trans('Whoops! Something went wrong.'); // -> "Oups ! Un problème est survenu."
```

Related issue: #3