### PR TITLE
Support translation key with dot V2

### DIFF
--- a/src/js/Localization/core.ts
+++ b/src/js/Localization/core.ts
@@ -198,7 +198,7 @@ class Localization {
     for (const part of parts) {
       // Get the new json until we fall on the last key of
       // the array which should point to a String.
-      if (part in link) {
+      if (typeof link === 'object' && part in link) {
         // Make sure the key exist.
         link = link[part]
       } else {

--- a/src/js/Localization/core.ts
+++ b/src/js/Localization/core.ts
@@ -182,29 +182,31 @@ class Localization {
    * @param key
    * @param silentNotFoundError
    * @param locale
+   * @param splitKey
    * @returns {string}
    * @private
    */
-  private findSentence(key: string, silentNotFoundError: boolean, locale: string = MaticeLocalizationConfig.locale): string {
+  private findSentence(key: string, silentNotFoundError: boolean, locale: string = MaticeLocalizationConfig.locale, splitKey: boolean = false): string {
     const translations: { [key: string]: any } = this.translations(locale)
 
     // At first [link] is a [Map<String, dynamic>] but at the end, it can be a [String],
     // the sentences.
     let link = translations
 
-    const parts = key.split('.')
+    const parts = splitKey ? key.split('.') : [key]
 
     for (const part of parts) {
       // Get the new json until we fall on the last key of
       // the array which should point to a String.
-      try {
-        // Make sure the _key exist.
-        // If not this throws an error that is handled by the "catch" block
-        // @ts-ignore
-        assert(link[part])
-        // @ts-ignore
+      if (part in link) {
+        // Make sure the key exist.
         link = link[part]
-      } catch (e) {
+      } else {
+        // If key not found, try to split it using dot.
+        if (!splitKey) {
+          return this.findSentence(key, silentNotFoundError, locale, true)
+        }
+
         // If key not found, try with the fallback locale.
         if (locale !== MaticeLocalizationConfig.fallbackLocale) {
           return this.findSentence(key, silentNotFoundError, MaticeLocalizationConfig.fallbackLocale)

--- a/tests/js/manage_translation.test.ts
+++ b/tests/js/manage_translation.test.ts
@@ -14,7 +14,9 @@ global.Matice = {
     "fr": {
       "greet": {
         "me": "Bonjour!"
-      }
+      },
+      "Key with one dot. Should be OK": "Avec un point, c'est bien.",
+      "Key with dots. Should be better...": "Avec plusieurs points, c'est mieux..."
     }
   },
   "locale": "en",
@@ -50,6 +52,14 @@ test('Retrieves simple sentence.', () => {
   // greet.meMore in french so fallback to english.
   sentence = __('greet.meMore')
   expect(sentence).toEqual('Hello Ekcel Henrich!')
+    
+  // Test translation key with one dot
+  sentence = trans('Key with one dot. Should be OK')
+  expect(sentence).toEqual("Avec un point, c'est bien.")
+    
+  // Test translation key with multiple dots
+  sentence = trans('Key with dots. Should be better...')
+  expect(sentence).toEqual("Avec plusieurs points, c'est mieux...")
 });
 
 


### PR DESCRIPTION
Add a `splitKey` flag to the [`Localization::findSentence()`](https://github.com/GENL/matice/blob/50c08a0c12643bd8077e006e1aa9100e1445db87/src/js/Localization/core.ts#L188) method.

With this patch, `findSentence()` method will try to get the translation key as it is and if it doesn't exist, it will try to split it using dot (`.`).

Similar behavior is used in the Laravel Framework (https://github.com/laravel/framework/blob/v8.13.0/src/Illuminate/Translation/Translator.php#L111)

Sample:
```javascript
trans('Whoops! Something went wrong.'); // -> "Oups ! Un problème est survenu."

trans('auth.failed'); // -> 'Ces identifiants ne correspondent pas à nos enregistrements'
```

NB: This is a newer and better version of the pull request #4

Related issue: #3