### PR TITLE
 PHP 7.2 and 8.0 support 🚀

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
           # Laravel >= 8.0 doesn't support PHP 7.2
           - php: 7.2
             laravel: 8.*
-            testbench: 6.*
         include:
           - laravel: 6.*
             testbench: 4.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4]
+        php: [7.2, 7.3, 7.4, 8.0]
         laravel: [6.*, 7.*, 8.*]
+        exclude:
+          # Laravel >= 8.0 doesn't support PHP 7.2
+          - php: 7.2
+            laravel: 8.*
+            testbench: 6.*
         include:
           - laravel: 6.*
             testbench: 4.*
@@ -62,5 +67,3 @@ jobs:
 
       - name: Run Jest tests
         run: npm test
-
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
+  - 8.0snapshot
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    # Laravel >= 8.0 doesn't support PHP 7.2
+    - php: 7.2
+      env: COMPOSER_FLAGS="--prefer-lowest"
 
 env:
-  matrix:
     - COMPOSER_FLAGS="--prefer-lowest"
     - COMPOSER_FLAGS=""
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,9 @@ php:
   - 7.4
   - 8.0snapshot
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    # Laravel >= 8.0 doesn't support PHP 7.2
-    - php: 7.2
-      env: COMPOSER_FLAGS="--prefer-lowest"
-
 env:
-    - COMPOSER_FLAGS="--prefer-lowest"
-    - COMPOSER_FLAGS=""
+  - COMPOSER_FLAGS="--prefer-lowest"
+  - COMPOSER_FLAGS=""
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/framework": ">=6.0@dev"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0"
+        "orchestra/testbench": "^4.10||^5.0||^6.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add PHP 7.2 support because Laravel 6 use it and it's the current [LTS version](https://laravel.com/docs/8.x/releases#support-policy)