### PR TITLE
pluralization with two parts: singular and plural

### DIFF
--- a/src/js/Localization/core.ts
+++ b/src/js/Localization/core.ts
@@ -111,7 +111,7 @@ class Localization {
     // We fill the empty indexes with a direct preceding index.
     // We fill the empty parts by the last part.
     if (parts.length >= 3) parts = [parts[0], parts[1], parts[2]]
-    else if (parts.length === 2) parts = [parts[0], parts[1], parts[1]]
+    else if (parts.length === 2) parts = [parts[0], parts[0], parts[1]]
     else parts = [parts[0], parts[0], parts[0]]
 
     // Manage multiple number range.

--- a/tests/js/manage_translation.test.ts
+++ b/tests/js/manage_translation.test.ts
@@ -9,7 +9,8 @@ global.Matice = {
         "meMore": "Hello Ekcel Henrich!",
         "people": "Hello Ekcel!|Hello everyone!",
       },
-      "balance": "{0} You're broke|[1000, 5000] a middle man|[1000000,*] You are awesome :name; :count Million Dollars"
+      "balance": "{0} You're broke|[1000, 5000] a middle man|[1000000,*] You are awesome :name; :count Million Dollars",
+      "pluralTwoSegments": "One user|Many users",
     },
     "fr": {
       "greet": {
@@ -81,6 +82,12 @@ test('Pluralize the sentence well', () => {
 
   sentence = transChoice('balance', 8578442, {name: 'Ekcel'})
   expect(sentence).toEqual(" You are awesome Ekcel; 8578442 Million Dollars")
+
+  sentence = transChoice('pluralTwoSegments', 1)
+  expect(sentence).toEqual("One user")
+
+  sentence = transChoice('pluralTwoSegments', 2)
+  expect(sentence).toEqual("Many users")
 });
 
 test('Test that the locale can be forced', () => {


### PR DESCRIPTION
fixes #32 

This PR makes a translation with two parts be singular and plural like the Laravel convention https://laravel.com/docs/master/localization#pluralization