### PR TITLE
Fix issues with "null" locale

### DIFF
--- a/config/matice.php
+++ b/config/matice.php
@@ -9,7 +9,7 @@ return [
      *
      * The path(directory) where matice finds the translations to work with.
      */
-    'lang_directory' => function_exists('lang_path') ? lang_path() : resource_path('lang'),
+    'lang_directory' => lang_path(),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/matice.php
+++ b/config/matice.php
@@ -9,7 +9,7 @@ return [
      *
      * The path(directory) where matice finds the translations to work with.
      */
-    'lang_directory' => lang_path(),
+    'lang_directory' => function_exists('lang_path') ? lang_path() : resource_path('lang'),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/BladeTranslationsGenerator.php
+++ b/src/BladeTranslationsGenerator.php
@@ -42,6 +42,7 @@ class BladeTranslationsGenerator
 
     private function makeMaticeObject(?string $locale): string
     {
+        $locale = $locale ?? config('app.locale');
         $translations = json_encode($this->translations($locale));
         $appLocale = $locale ?? app()->getLocale();
         $fallbackLocale = config('app.fallback_locale');

--- a/src/MaticeServiceProvider.php
+++ b/src/MaticeServiceProvider.php
@@ -4,9 +4,7 @@ namespace Genl\Matice;
 
 use Genl\Matice\Commands\TranslationsGeneratorCommand;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Illuminate\Translation\Translator;
 
 class MaticeServiceProvider extends ServiceProvider
@@ -19,30 +17,12 @@ class MaticeServiceProvider extends ServiceProvider
         /*
          * Optional methods to load your package assets
          */
-        // $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'matice');
-        // $this->loadViewsFrom(__DIR__.'/../resources/views', 'matice');
-        // $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-        // $this->loadRoutesFrom(__DIR__.'/routes.php');
-
+      
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../config/matice.php' => config_path('matice.php'),
             ], 'config');
 
-            // Publishing the views.
-            /*$this->publishes([
-                __DIR__.'/../resources/views' => resource_path('views/vendor/matice'),
-            ], 'views');*/
-
-            // Publishing assets.
-            /*$this->publishes([
-                __DIR__.'/../resources/assets' => public_path('vendor/matice'),
-            ], 'assets');*/
-
-            // Publishing the translation files.
-            /*$this->publishes([
-                __DIR__.'/../resources/lang' => resource_path('lang/vendor/matice'),
-            ], 'lang');*/
         }
 
         // Registering package commands.


### PR DESCRIPTION
- when locale is null in makeMaticeObject  the translations file crash
- in config i just use the lang_path() because this method already exists in laravel
- At the end i clean the comment in the service provider