### PR TITLE
Respect additional JSON paths from Laravel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.2, 7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
+        laravel: [6.*, 7.*, 8.*, 9.*]
         exclude:
-          # Laravel >= 8.0 doesn't support PHP 7.2
-          - php: 7.2
-            laravel: 8.*
+          # Laravel >= 6.0 doesn't support PHP 7.2 or >= 8.1
+          - laravel: 6.*
+            php: 8.1
+          - laravel: 6.*
+            php: 8.2
+
+          # Laravel >= 7.0 doesn't support PHP 7.2 or >= 8.1
+          - laravel: 7.*
+            php: 8.1
+          - laravel: 7.*
+            php: 8.2
+
+          # Laravel >= 8.0 doesn't support PHP 7.2 or >= 8.2
+          - laravel: 8.*
+            php: 7.2
+          - laravel: 8.*
+            php: 8.2
+
+          # Laravel >= 9.0 doesn't support PHP <= 7.4
+          - laravel: 9.*
+            php: 7.2
+          - laravel: 9.*
+            php: 7.3
+          - laravel: 9.*
+            php: 7.4
+
         include:
           - laravel: 6.*
             testbench: 4.*
@@ -28,6 +51,8 @@ jobs:
             testbench: 5.*
           - laravel: 8.*
             testbench: 6.*
+          - laravel: 9.*
+            testbench: 7.*
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/framework": ">=6.0@dev"
     },
     "require-dev": {
-        "orchestra/testbench": "^4.10||^5.0||^6.0"
+        "orchestra/testbench": "^4.10||^5.0||^6.0||^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -72,7 +72,7 @@ class Helpers
         $ffs = scandir($localeFolder);
 
         foreach ($ffs as $ff) {
-            // We skip hidden folders or config files the directory.
+            // We skip hidden folders or config files in the directory.
             if (Str::startsWith($ff, '.')) {
                 continue;
             }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -6,6 +6,7 @@ namespace Genl\Matice;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Str;
 
 class Helpers
@@ -20,28 +21,87 @@ class Helpers
     public static function makeFolderFilesTree($dir): array
     {
         $tree = [];
-        $ffs = scandir($dir);
-        foreach ($ffs as $ff) {
-            if (!Str::startsWith($ff, '.')) { // We skip hidden folders or config files the directory.
-                $extension = '.' . Str::afterLast($ff, '.');
-                $ff = basename($ff, $extension);
-                $tree[$ff] = [];
-                if (is_dir($dir . '/' . $ff)) {
-                    $tree[$ff] = MaticeServiceProvider::makeFolderFilesTree($dir . '/' . $ff);
+        $localeFolders = File::directories($dir);
+
+        foreach ($localeFolders as $localeFolder) {
+            $locale = basename($localeFolder);
+
+            $tree[$locale] = self::readLocaleFolder($localeFolder);
+        }
+
+        $jsonPaths = self::getJsonPaths($dir);
+
+        foreach ($jsonPaths as $jsonPath) {
+            $files = File::files($jsonPath);
+
+            foreach ($files as $file) {
+                if ($file->getExtension() !== 'json') {
+                    continue;
                 }
-                if (is_file($pathName = $dir . '/' . $ff . $extension)) {
-                    if ($extension === '.json') {
-                        $existingTranslations = $tree[$ff] ?? [];
-                        $tree[$ff] = array_merge(
-                            $existingTranslations,
-                            json_decode(File::get($pathName), true)
-                        );
-                    } else if ($extension === '.php') {
-                        $tree[$ff] = require($pathName);
-                    }
+
+                $locale = $file->getFilenameWithoutExtension();
+
+                $tree[$locale] = array_merge(
+                    $tree[$locale] ?? [],
+                    json_decode($file->getContents(), true)
+                );
+            }
+        }
+
+        return $tree;
+    }
+
+    private static function getJsonPaths($dir): array
+    {
+        $jsonPaths = [];
+
+        if (method_exists(Lang::getLoader(), 'jsonPaths')) {
+            $jsonPaths = Lang::getLoader()->jsonPaths();
+        } elseif (method_exists(Lang::getLoader(), 'getJsonPaths')) {
+            $jsonPaths = Lang::getLoader()->getJsonPaths();
+        }
+
+        return array_unique(
+            array_merge([$dir], $jsonPaths)
+        );
+    }
+
+    private static function readLocaleFolder(string $localeFolder): array
+    {
+        $tree = [];
+        $ffs = scandir($localeFolder);
+
+        foreach ($ffs as $ff) {
+            // We skip hidden folders or config files the directory.
+            if (Str::startsWith($ff, '.')) {
+                continue;
+            }
+
+            $extension = '.' . Str::afterLast($ff, '.');
+            $ff = basename($ff, $extension);
+            $tree[$ff] = [];
+
+            if (is_dir($localeFolder . '/' . $ff)) {
+                $tree[$ff] = self::readLocaleFolder($localeFolder . '/' . $ff);
+            }
+
+            if (is_file($pathName = $localeFolder . '/' . $ff . $extension)) {
+                $existingTranslations = $tree[$ff] ?? [];
+
+                if ($extension === '.json') {
+                    $tree[$ff] = array_merge(
+                        $existingTranslations,
+                        json_decode(File::get($pathName), true)
+                    );
+                } else if ($extension === '.php') {
+                    $tree[$ff] = array_merge(
+                        $existingTranslations,
+                        require($pathName)
+                    );
                 }
             }
         }
+
         return $tree;
     }
 

--- a/tests/Unit/ManageTranslationTest.php
+++ b/tests/Unit/ManageTranslationTest.php
@@ -6,6 +6,7 @@ use Genl\Matice\Facades\Matice;
 use Genl\Matice\Tests\TestCase;
 use Illuminate\Support\Facades\Blade;
 use Genl\Matice\MaticeServiceProvider;
+use Illuminate\Support\Facades\Lang;
 
 class ManageTranslationTest extends TestCase
 {
@@ -35,10 +36,38 @@ class ManageTranslationTest extends TestCase
         $this->assertIsArray($translations);
 
         $this->assertArrayHasKey('en', $translations);
+        $this->assertCount(4, $translations['en']);
 
-        $this->assertCount(3, $translations['en']);
+        $this->assertStringContainsString("Hi! I'm a json translation text.", json_encode($translations['en']));
 
-        $this->assertStringContainsString("Hi! I'm a json translation text.", json_encode($translations));
+        $this->assertArrayHasKey('From default json file', $translations['en']);
+        $this->assertContains("Hi! I'm fom a default json translation file.", $translations['en']);
+    }
+
+    public function test_load_translations_from_additional_json_paths()
+    {
+        $supportsJsonPaths = method_exists(Lang::getLoader(), 'jsonPaths') || method_exists(Lang::getLoader(), 'getJsonPaths');
+
+        if (!$supportsJsonPaths) {
+            $this->markTestSkipped('The current Laravel version does not support loading translations from additional json paths.');
+        }
+
+        Lang::addJsonPath(__DIR__ . ('/../../tests/assets/additional_json_files'));
+
+        $translations = Matice::translations();
+
+        $this->assertIsArray($translations);
+
+        $this->assertArrayHasKey('en', $translations);
+        $this->assertCount(5, $translations['en']);
+
+        $this->assertStringContainsString("Hi! I'm a json translation text.", json_encode($translations['en']));
+
+        $this->assertArrayHasKey('From default json file', $translations['en']);
+        $this->assertContains("Hi! I'm fom a default json translation file.", $translations['en']);
+
+        $this->assertArrayHasKey('From additional json file', $translations['en']);
+        $this->assertContains("Hi! I'm fom an additional json translation file.", $translations['en']);
     }
 
     public function test_generate_translation_js()

--- a/tests/assets/additional_json_files/en.json
+++ b/tests/assets/additional_json_files/en.json
@@ -1,0 +1,3 @@
+{
+    "From additional json file": "Hi! I'm fom an additional json translation file."
+}

--- a/tests/assets/lang/en.json
+++ b/tests/assets/lang/en.json
@@ -1,0 +1,3 @@
+{
+    "From default json file": "Hi! I'm fom a default json translation file."
+}


### PR DESCRIPTION
Laravel allows a developer to register additional folders that contain JSON based translation files.

The Matice package did not respect these additional folders, causing a difference in the translations loaded server side and client side.

This PR adds support for additional JSON paths since Laravel 8.

---

I also added Laravel 9 and additional PHP versions to the test suite. The current test suite does not support Laravel 10 or up because the PHPUnit configuration syntax is too old for the PHPUnit version used since Laravel 10. If it's fine to drop support for Laravel <= 8, I suppose it would be easier to write tests for newer Laravel versions.