### PR TITLE
Check jsonPath existence before accessing files

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -38,9 +38,7 @@ class Helpers
                     if ($file->getExtension() !== 'json') {
                         continue;
                     }
-
                     $locale = $file->getFilenameWithoutExtension();
-
                     $tree[$locale] = array_merge(
                         $tree[$locale] ?? [],
                         json_decode($file->getContents(), true)

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -32,19 +32,20 @@ class Helpers
         $jsonPaths = self::getJsonPaths($dir);
 
         foreach ($jsonPaths as $jsonPath) {
-            $files = File::files($jsonPath);
+            if(File::exists($jsonPath)) {
+                $files = File::files($jsonPath);
+                foreach ($files as $file) {
+                    if ($file->getExtension() !== 'json') {
+                        continue;
+                    }
 
-            foreach ($files as $file) {
-                if ($file->getExtension() !== 'json') {
-                    continue;
+                    $locale = $file->getFilenameWithoutExtension();
+
+                    $tree[$locale] = array_merge(
+                        $tree[$locale] ?? [],
+                        json_decode($file->getContents(), true)
+                    );
                 }
-
-                $locale = $file->getFilenameWithoutExtension();
-
-                $tree[$locale] = array_merge(
-                    $tree[$locale] ?? [],
-                    json_decode($file->getContents(), true)
-                );
             }
         }
 

--- a/tests/Unit/ManageTranslationTest.php
+++ b/tests/Unit/ManageTranslationTest.php
@@ -70,6 +70,21 @@ class ManageTranslationTest extends TestCase
         $this->assertContains("Hi! I'm fom an additional json translation file.", $translations['en']);
     }
 
+    public function test_no_fail_when_translations_json_paths_doesnt_exist()
+    {
+        $supportsJsonPaths = method_exists(Lang::getLoader(), 'jsonPaths') || method_exists(Lang::getLoader(), 'getJsonPaths');
+
+        if (!$supportsJsonPaths) {
+            $this->markTestSkipped('The current Laravel version does not support loading translations from additional json paths.');
+        }
+
+        Lang::addJsonPath(__DIR__ . ('/../../tests/assets/non_existent_route'));
+
+        $this->expectNotToPerformAssertions();
+
+        Matice::translations();
+    }
+
     public function test_generate_translation_js()
     {
         $jsOutput = Matice::generate();

--- a/tests/Unit/ManageTranslationTest.php
+++ b/tests/Unit/ManageTranslationTest.php
@@ -77,11 +77,8 @@ class ManageTranslationTest extends TestCase
         if (!$supportsJsonPaths) {
             $this->markTestSkipped('The current Laravel version does not support loading translations from additional json paths.');
         }
-
         Lang::addJsonPath(__DIR__ . ('/../../tests/assets/non_existent_route'));
-
         $this->expectNotToPerformAssertions();
-
         Matice::translations();
     }
 

--- a/tests/Unit/ManageTranslationTest.php
+++ b/tests/Unit/ManageTranslationTest.php
@@ -73,7 +73,6 @@ class ManageTranslationTest extends TestCase
     public function test_no_fail_when_translations_json_paths_doesnt_exist()
     {
         $supportsJsonPaths = method_exists(Lang::getLoader(), 'jsonPaths') || method_exists(Lang::getLoader(), 'getJsonPaths');
-
         if (!$supportsJsonPaths) {
             $this->markTestSkipped('The current Laravel version does not support loading translations from additional json paths.');
         }


### PR DESCRIPTION
Previously, the code assumed that jsonPath always existed, leading to possible errors. This update adds a check to ensure that jsonPath exists before attempting to access its files, improving stability and error handling.

Issue detected when the https://github.com/ebess/advanced-nova-media-library package is installed in the project. This adds a lang path that does not exist:
```sh
/var/www/html/vendor/ebess/advanced-nova-media-library/src/../resources/lang
```