### PR TITLE
Fix deprecated warning for null limit in preg_split()

### DIFF
--- a/src/BladeTranslationsGenerator.php
+++ b/src/BladeTranslationsGenerator.php
@@ -40,7 +40,7 @@ class BladeTranslationsGenerator
             preg_split(
                 '/,/',
                 preg_replace('/\s/', '', $locales),
-                null,
+                -1,
                 PREG_SPLIT_NO_EMPTY
             );
         // Given a list of locales, we want to make sure the fallback local


### PR DESCRIPTION
Replaced `null` with `-1` as the limit parameter in `preg_split()` to fix the deprecation warning in PHP 8.1+.

Closes #51 